### PR TITLE
Draft: Multithread by document id

### DIFF
--- a/buffers.go
+++ b/buffers.go
@@ -1,0 +1,41 @@
+package es_writer
+
+import (
+	"regexp"
+	"strconv"
+
+	"github.com/go1com/es-writer/action"
+)
+
+func AnyNotEmpty(buffers []*action.Container) bool {
+	for _, buf := range buffers {
+		if buf.Length() > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func GetBufferIndexFromId(id *string, numQueues int) int {
+	regex := regexp.MustCompile("[0-9]+")
+	if id == nil {
+		return 0
+	}
+	items := regex.FindAllString(*id, -1)
+	if len(items) < 1 {
+		return 0
+	}
+	numericId, err := strconv.Atoi(items[len(items)-1])
+	if err != nil {
+		return 0
+	}
+	return numericId % numQueues
+}
+
+func TotalElements(buffers []*action.Container) int {
+	var total = 0
+	for _, buf := range buffers {
+		total += buf.Length()
+	}
+	return total
+}

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -59,7 +59,7 @@ func container() Container {
 
 func idle(app *App) {
 	for {
-		units := app.buffer.Length()
+		units := TotalElements(app.buffers)
 		if 0 == units {
 			time.Sleep(3333 * time.Millisecond)
 			break

--- a/es-query.go
+++ b/es-query.go
@@ -1,0 +1,58 @@
+package es_writer
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/go1com/es-writer/action"
+)
+
+func GetDocumentIdFromUri(uri string) *string {
+	// Get parts of URI
+	info := strings.Split(uri, "/")
+
+	if len(info) >= 4 {
+		// Return document id if it exists
+		res, err := regexp.MatchString("[0-9]+", info[3])
+		if res && err == nil {
+			return &info[3]
+		}
+	}
+
+	return nil
+}
+
+func GetDocumentIdFromBody(body interface{}) *string {
+	// Stringify json
+	bodyStr := fmt.Sprint(body)
+
+	// Split into string before _id and after
+	parts := strings.SplitN(bodyStr, "_id:", 2)
+	if len(parts) < 2 {
+		return nil
+	}
+
+	// Extract string before closing bracket or space
+	field := strings.SplitN(parts[1], "]", 2)[0]
+	field = strings.SplitN(field, " ", 2)[0]
+	return &field
+}
+
+func GetDocumentIdFromElement(query *action.Element) *string {
+
+	// Return nil if element does not exist
+	if query == nil {
+		return nil
+	}
+
+	// Get document id from uri
+	uriDocId := GetDocumentIdFromUri(query.Uri)
+
+	if uriDocId != nil {
+		return uriDocId
+	}
+
+	// Return document id from body
+	return GetDocumentIdFromBody(query.Body)
+}


### PR DESCRIPTION
Rather than sending one bulk es request at a time, this
distributes the messages into multiple buffers by document id using
the modulus function and then runs multiple threads to send multiple
bulk requests at the same time.